### PR TITLE
Makefile update: the Helm chart path could be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PORT?=80
 PROBES_PORT?=81
 
 # Help variables
-HELM_CHART_PATH=./helm
+HELM_CHART_PATH?=./helm
 
 # This entry point provides functionality to check that required variable is set.
 guard-%:


### PR DESCRIPTION
Just use this code in your Makefile:

```shell script
HELM_CHART_PATH=./deployments/helm
```